### PR TITLE
Fix typographical error(s)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ Installation
 3. Go to `openXMarkedText` settings, and tune styles/limits
   - (!) Don't use double quotes in attributes, only single one. OX has a bug, and " in config file crashes everything 
 4. Create Text Zone, Users, Text campaigns.
-5. That's all. For text campains users will be able to manage their banners:
+5. That's all. For text campaigns users will be able to manage their banners:
   - start/stop
   - create new
 


### PR DESCRIPTION
@rcdesign, I've corrected a typographical error in the documentation of the [openx-markedtext](https://github.com/rcdesign/openx-markedtext) project. Specifically, I've changed campain to campaign. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
